### PR TITLE
Ensure that the tmpdir is on the same device as the destination.

### DIFF
--- a/lib/atomos.rb
+++ b/lib/atomos.rb
@@ -12,6 +12,12 @@ module Atomos
 
     require 'tempfile'
 
+    # Ensure the destination is on the same device as tmpdir
+    if File.stat(tmpdir).dev != File.stat(File.dirname(dest)).dev
+      # If not, use the directory of the destination as the tmpdir.
+      tmpdir = File.dirname(dest)
+    end
+
     Tempfile.open(".atomos.#{File.basename(dest)}", tmpdir) do |tmpfile|
       if contents
         tmpfile << contents


### PR DESCRIPTION
An atomic rename can only be performed if both the source and
destination are on the same device. Because of this, fallback
to using the destination file's directory as tmpdir if it
would otherwise span devices.