### PR TITLE
Requires ‘tmpdir’ to fix NoMethodError

### DIFF
--- a/lib/atomos.rb
+++ b/lib/atomos.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'atomos/version'
+require 'tmpdir'
 
 module Atomos
   module_function


### PR DESCRIPTION
Hello :)

I have no idea of what this project does. But while I was using `ib` gem and in my setup, this library is trying to request for `Dir.tmpdir` without having the `tmpdir` method available.

After doing this change, things went fine.

Peace 🙏🏾