### PR TITLE
close tmpfile before renaming/moving

### DIFF
--- a/lib/atomos.rb
+++ b/lib/atomos.rb
@@ -5,6 +5,7 @@ require 'atomos/version'
 module Atomos
   module_function
 
+  # rubocop:disable Metrics/MethodLength
   def atomic_write(dest, contents = nil, tmpdir: nil, &block)
     unless contents.nil? ^ block.nil?
       raise ArgumentError, 'must provide either contents or a block'
@@ -20,11 +21,14 @@ module Atomos
         retval = yield tmpfile
       end
 
+      tmpfile.close
+
       File.rename(tmpfile.path, dest)
 
       retval
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def self.default_tmpdir_for_file(dest, tmpdir)
     tmpdir ||= begin


### PR DESCRIPTION
See #5 for bug description.

Before:
```
C:\Users\Jan\Documents\atomos (master -> origin)
λ bundle exec rspec

Atomos
  has a version number
  #atomic_write
    raises when no contents or block is given
    raises when both contents and block are given
    writes (FAILED - 1)

Failures:

  1) Atomos#atomic_write writes
     Failure/Error: File.rename(tmpfile.path, dest)

     Errno::EACCES:
       Permission denied @ rb_file_s_rename - (C:/Users/Jan/AppData/Local/Temp/.atomos.target20180806-21832-1nm9tci, C:/Users/Jan/AppData/Local/Temp/d20180806-21832-odi5ri/target)
     # ./lib/atomos.rb:23:in `rename'
     # ./lib/atomos.rb:23:in `block in atomic_write'
     # ./lib/atomos.rb:16:in `atomic_write'
     # ./spec/atomos_spec.rb:26:in `block (3 levels) in <top (required)>'

Finished in 0.03798 seconds (files took 0.37877 seconds to load)
4 examples, 1 failure

Failed examples:

rspec ./spec/atomos_spec.rb:25 # Atomos#atomic_write writes
```

After
```
C:\Users\Jan\Documents\atomos (master -> origin)
λ bundle exec rspec

Atomos
  has a version number
  #atomic_write
    raises when no contents or block is given
    raises when both contents and block are given
    writes

Finished in 0.45133 seconds (files took 3.1 seconds to load)
4 examples, 0 failures
```

fixes #5
helps with https://github.com/CocoaPods/Xcodeproj/issues/549